### PR TITLE
Automate report creation

### DIFF
--- a/.github/workflows/relability_report.yml
+++ b/.github/workflows/relability_report.yml
@@ -1,0 +1,35 @@
+# Set those repository secrets
+# (https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
+# USER_NAME - GitHub user name
+# USER_TOKEN - GitHub access token
+# JENKINS_TOKEN - GitHub user Jenkins token
+
+name: Update CI reliability
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  
+jobs:
+  create-report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - run: npm i -g node-core-utils
+    - run: ncu-config --global set jenkins_token ${{ secrets.JENKINS_TOKEN }}
+    - run: ncu-config --global set token ${{ secrets.USER_TOKEN }}
+    - run: ncu-config --global set username ${{ secrets.USER_NAME }}
+    - run: ncu-ci walk pr --stats=true --markdown $PWD/results.md
+    - run: |
+        body=`cat results.md | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))'`
+        title_date=$(date +%Y-%m-%d)
+        curl --request POST \
+        --url https://api.github.com/repos/${GITHUB_REPOSITORY}/issues \
+        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+        --header 'content-type: application/json' \
+        --data "{
+          \"title\": \"CI Reliability ${title_date}\",
+          \"body\": ${body}
+          }"


### PR DESCRIPTION
Add Github Action that will use node-core-utils and create a reliability report at every UTC midnight. 

A sample generated report can be viewed [here](https://github.com/JaneaSystems/nodejs-reliability/issues/4).

Besides landing, this requires some configuration to the repository itself. Three  [secret values](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) are needed for the script to run (required by node-core-utils):
 * `JENKINS_TOKEN` - Jenkins access token
 * `USER_NAME` and `USER_TOKEN` - GitHub user name and access token

I've tried running this with a newly created user, but the `ncu-walk` failed. It also looks like Jenkins and GitHub tokens must "match". It defiantly works when I gave the script my tokens, we will have to create a robot user and gave it the required access.