### PR TITLE
fix: avoid Argument list too long error

### DIFF
--- a/.github/workflows/reliability_report.yml
+++ b/.github/workflows/reliability_report.yml
@@ -9,27 +9,27 @@ name: Update CI reliability
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
   
 jobs:
   create-report:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3.0.0
       with:
-        node-version: 12
+        node-version: 16
     - run: npm i -g node-core-utils
     - run: ncu-config --global set jenkins_token ${{ secrets.JENKINS_TOKEN }}
     - run: ncu-config --global set token ${{ secrets.USER_TOKEN }}
     - run: ncu-config --global set username ${{ secrets.USER_NAME }}
     - run: ncu-ci walk pr --stats=true --markdown $PWD/results.md
-    - run: |
-        body=`cat results.md | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))'`
+    - run: |      
         title_date=$(date +%Y-%m-%d)
+        echo "{ \"title\": \"CI Reliability ${title_date}\", \"body\": " >> body.json
+        cat results.md | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))' >> body.json
+        echo "}" >> body.json
         curl --request POST \
         --url https://api.github.com/repos/${GITHUB_REPOSITORY}/issues \
         --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
         --header 'content-type: application/json' \
-        --data "{
-          \"title\": \"CI Reliability ${title_date}\",
-          \"body\": ${body}
-          }"
+        --data @body.json


### PR DESCRIPTION
Pass POST data to curl via a file to avoid getting an
`Argument list too long` error.

Fixes: https://github.com/nodejs/reliability/issues/211