### PR TITLE
fix: use Node.js LTS version in workflow

### DIFF
--- a/.github/workflows/reliability_report.yml
+++ b/.github/workflows/reliability_report.yml
@@ -15,9 +15,9 @@ jobs:
   create-report:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: lts/*
     - run: npm i -g @node-core/utils
     - run: ncu-config --global set jenkins_token ${{ secrets.JENKINS_TOKEN }}
     - run: ncu-config --global set token ${{ secrets.USER_TOKEN }}


### PR DESCRIPTION
`@node-core/utils` doesn't support Node.js 16 anymore.
