### PR TITLE
Close older reliability reports

### DIFF
--- a/.github/workflows/close_report_issues.yml
+++ b/.github/workflows/close_report_issues.yml
@@ -1,0 +1,19 @@
+name: 'Close old reliability reports'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+    issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'Closing old reliability report in **1** day'
+          close-issue-message: 'Closed old reliability report'
+          only-labels: 'reliability-report'
+          days-before-stale: 6
+          days-before-close: 1

--- a/.github/workflows/reliability_report.yml
+++ b/.github/workflows/reliability_report.yml
@@ -24,13 +24,9 @@ jobs:
     - run: ncu-config --global set username ${{ secrets.USER_NAME }}
     - run: ncu-ci walk pr --stats=true --markdown $PWD/results.md
     - run: cat $PWD/results.md >> $GITHUB_STEP_SUMMARY
-    - run: |      
+    - run: | 
         title_date=$(date +%Y-%m-%d)
-        echo "{ \"title\": \"CI Reliability ${title_date}\", \"body\": " >> body.json
-        cat results.md | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))' >> body.json
-        echo "}" >> body.json
-        curl --request POST \
-        --url https://api.github.com/repos/${GITHUB_REPOSITORY}/issues \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-        --header 'content-type: application/json' \
-        --data @body.json
+        gh issue create \
+        --title "CI Reliability ${title_date}" \
+        --body "$(cat results.md)" \
+        --label reliability-report


### PR DESCRIPTION
In my opinion, the number of reliability issues may be *a bit* much, as the report is re-generated every day. This PR will close reliability report issues after 1 week so that the issues remain in a constant flow of the newest information.

If this idea isn't the 'best' one, feel free to point me in the direction of where my contributions will make the most impact :-).