### PR TITLE
feat: close older reports

### DIFF
--- a/.github/workflows/close_old_reports.yml
+++ b/.github/workflows/close_old_reports.yml
@@ -1,0 +1,19 @@
+name: 'Close old reliability reports'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+    issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'Due to inactivity on this reliability report, it is being closed in 48 hours, unless additional activity occurs.'
+          close-issue-message: 'Due to inactivity on this reliability report, it has been closed.'
+          only-labels: 'reliability-report'
+          days-before-stale: 7
+          days-before-close: 2

--- a/.github/workflows/reliability_report.yml
+++ b/.github/workflows/reliability_report.yml
@@ -24,13 +24,9 @@ jobs:
     - run: ncu-config --global set username ${{ secrets.USER_NAME }}
     - run: ncu-ci walk pr --stats=true --markdown $PWD/results.md
     - run: cat $PWD/results.md >> $GITHUB_STEP_SUMMARY
-    - run: |      
+    - run: |
         title_date=$(date +%Y-%m-%d)
-        echo "{ \"title\": \"CI Reliability ${title_date}\", \"body\": " >> body.json
-        cat results.md | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))' >> body.json
-        echo "}" >> body.json
-        curl --request POST \
-        --url https://api.github.com/repos/${GITHUB_REPOSITORY}/issues \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-        --header 'content-type: application/json' \
-        --data @body.json
+        gh issue create \
+        --title "CI Reliability ${title_date}" \
+        --body "$(cat results.md)" \
+        --label reliability-report


### PR DESCRIPTION
This PR adds a workflow that will close older reliability reports, to keep the issue inbox uncluttered.

In order for this to work, the 'reliability-report' label needs to be added to the repo. Additionally, this (currently) will only affect future reports.