### PR TITLE
Commit the reports into repo and only use summary in issues

### DIFF
--- a/.github/workflows/reliability_report.yml
+++ b/.github/workflows/reliability_report.yml
@@ -6,6 +6,9 @@
 
 name: Update CI reliability
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: '0 0 * * *'
@@ -13,24 +16,44 @@ on:
   
 jobs:
   create-report:
+    name: Create and update the report
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: lts/*
-    - run: npm i -g @node-core/utils
-    - run: ncu-config --global set jenkins_token ${{ secrets.JENKINS_TOKEN }}
-    - run: ncu-config --global set token ${{ secrets.USER_TOKEN }}
-    - run: ncu-config --global set username ${{ secrets.USER_NAME }}
-    - run: ncu-ci walk pr --stats=true --markdown $PWD/results.md
-    - run: cat $PWD/results.md >> $GITHUB_STEP_SUMMARY
-    - run: |      
-        title_date=$(date +%Y-%m-%d)
-        echo "{ \"title\": \"CI Reliability ${title_date}\", \"body\": " >> body.json
-        cat results.md | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))' >> body.json
-        echo "}" >> body.json
-        curl --request POST \
-        --url https://api.github.com/repos/${GITHUB_REPOSITORY}/issues \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-        --header 'content-type: application/json' \
-        --data @body.json
+      - name: Clone reliability
+        uses: actions/checkout@v4
+        with:
+          path: reliability
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install @node-core/utils
+        run: npm install -g @node-core/utils
+
+      - name: Configure @node-core/utils
+        run: |
+          ncu-config --global set jenkins_token ${{ secrets.JENKINS_TOKEN }}
+          ncu-config --global set token ${{ secrets.USER_TOKEN }}
+          ncu-config --global set username ${{ secrets.USER_NAME }}
+
+      - name: Generate reports
+        run: |
+          cd reliability
+          ./generate-report.sh
+          cat ./progress.md >> $GITHUB_STEP_SUMMARY
+          cat ./reports/$(date +%Y-%m-%d).md >> $GITHUB_STEP_SUMMARY
+
+      - name: Create issue
+        run: |
+          title_date=$(date +%Y-%m-%d)
+          echo "{ \"title\": \"CI Reliability ${title_date}\", \"body\": " >> body.json
+          cat reliability/progress.md | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))' >> body.json
+          echo "}" >> body.json
+          curl --request POST \
+          --url https://api.github.com/repos/${GITHUB_REPOSITORY}/issues \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --data @body.json

--- a/generate-report.sh
+++ b/generate-report.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+mkdir -p reports
+DATENAME=$(date +"%Y-%m-%d")
+REPORT=reports/$DATENAME.md
+ncu-ci walk pr --stats=true --markdown $REPORT
+awk '/^### / {exit} {print}' $REPORT > progress.md
+echo "Open https://github.com/$GITHUB_REPOSITORY/blob/main/$REPORT to see failure details" >> progress.md
+echo -en "\n" >> progress.md
+
+awk '/^### Progress/ {found=1} found' $REPORT >> progress.md
+echo -en "\n" >> progress.md
+
+sed -i '/^### Progress/,$d' $REPORT
+git add ./reports
+git commit -m "Add report for $DATENAME"
+git push


### PR DESCRIPTION
To avoid failures due to issue body being too long.

I haven't tested this locally (not sure how to set it up) but I *think* it works. I tested the generate-reports.sh locally.